### PR TITLE
port/tuples just nothing

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -57,6 +57,8 @@ jobs:
           cabal build all --enable-tests --enable-per-component
 
       - name: Run tests with coverage-for library only
+        env:
+          HSPEC_OPTIONS: "--no-color"
         run: |
           set -euo pipefail
           # Ensure .tix files land in a predictable location

--- a/Makefile
+++ b/Makefile
@@ -21,7 +21,7 @@ lint:
 	fi
 
 test:
-	$(CABAL) test all --test-show-details=direct
+	HSPEC_OPTIONS="--no-color" $(CABAL) test all --test-show-details=direct
 
 check:
 	$(CABAL) check

--- a/PLAN.md
+++ b/PLAN.md
@@ -22,12 +22,13 @@ Keep this document up to date as a living record of porting progress from the Py
 - ✅ test_errors_on_too_large_choice
 - ✅ test_test_cases_satisfy_preconditions
 - ✅ test_error_on_too_strict_precondition
-- ✅ test_prints_a_top_level_weighted
-- ✅ test_impossible_weighted
+ - ✅ test_prints_a_top_level_weighted
+ - ✅ test_impossible_weighted
  - ✅ test_guaranteed_weighted
  - ✅ test_max_examples_is_not_exceeded
  - ✅ test_forced_choice_bounds
  - ✅ test_size_bounds_on_list
+ - ✅ test_cannot_witness_nothing
 
 ## Design Notes
 - Library module will be decomposed into `Minithesis.TestCase`, `Minithesis.State`, and generator modules as features land.

--- a/reference/test_minithesis.py
+++ b/reference/test_minithesis.py
@@ -348,7 +348,7 @@ def test_bound_possibility():
         assert m <= n <= m + 10
 
 
-def test_cannot_witness_nothing():
+def test_cannot_witness_nothing():  # -- PORTED
     with pytest.raises(Unsatisfiable):
 
         @run_test()

--- a/src/Minithesis.hs
+++ b/src/Minithesis.hs
@@ -13,6 +13,9 @@ module Minithesis
     any,
     integers,
     lists,
+    tuples,
+    just,
+    nothing,
     TestCase,
     forChoices,
     newTestCase,
@@ -330,6 +333,8 @@ weighted tc p
           printIfNeeded tc $ "weighted(" ++ show p ++ "): " ++ show res
           pure res
 
+-- Generators
+
 -- | Minimal strategy type for generator-based APIs.
 newtype Strategy a = Strategy {runStrategy :: TestCase -> IO a}
 
@@ -354,3 +359,18 @@ lists (Strategy elemS) minSize maxSize = Strategy $ \tc -> do
   k <- choice tc spanN
   let len = lo + fromIntegral k
   replicateM len (elemS tc)
+
+-- | Pair strategy combining two strategies.
+tuples :: Strategy a -> Strategy b -> Strategy (a, b)
+tuples (Strategy fa) (Strategy fb) = Strategy $ \tc -> do
+  a <- fa tc
+  b <- fb tc
+  pure (a, b)
+
+-- | Constant strategy.
+just :: a -> Strategy a
+just x = Strategy $ \_ -> pure x
+
+-- | Strategy that always rejects, forcing Unsatisfiable at the run level.
+nothing :: Strategy a
+nothing = Strategy $ \tc -> reject tc

--- a/test/Minithesis/Spec.hs
+++ b/test/Minithesis/Spec.hs
@@ -153,20 +153,4 @@ captureStdout action = do
   hClose oldStdout
   out <- readFile path
   removeFile path
-  pure (stripAnsi out, result)
-
--- Remove ANSI escape sequences from captured output to avoid
--- interference from the test runner's color codes.
-stripAnsi :: String -> String
-stripAnsi [] = []
-stripAnsi ('\ESC' : xs) = stripAnsi (skipAnsi xs)
-stripAnsi (x : xs) = x : stripAnsi xs
-
-skipAnsi :: String -> String
-skipAnsi [] = []
-skipAnsi (c : cs)
-  | isTerminator c = cs
-  | otherwise = skipAnsi cs
-  where
-    isTerminator ch =
-      (ch >= 'A' && ch <= 'Z') || (ch >= 'a' && ch <= 'z')
+  pure (out, result)

--- a/test/Minithesis/Spec.hs
+++ b/test/Minithesis/Spec.hs
@@ -153,4 +153,20 @@ captureStdout action = do
   hClose oldStdout
   out <- readFile path
   removeFile path
-  pure (out, result)
+  pure (stripAnsi out, result)
+
+-- Remove ANSI escape sequences from captured output to avoid
+-- interference from the test runner's color codes.
+stripAnsi :: String -> String
+stripAnsi [] = []
+stripAnsi ('\ESC' : xs) = stripAnsi (skipAnsi xs)
+stripAnsi (x : xs) = x : stripAnsi xs
+
+skipAnsi :: String -> String
+skipAnsi [] = []
+skipAnsi (c : cs)
+  | isTerminator c = cs
+  | otherwise = skipAnsi cs
+  where
+    isTerminator ch =
+      (ch >= 'A' && ch <= 'Z') || (ch >= 'a' && ch <= 'z')


### PR DESCRIPTION
- **test: add red tests for tuples/just/nothing generators [RED]**
- **feat(generators): add Strategy, any, integers, tuples, just, nothing; port tests [GREEN]**
- **docs: mark test_cannot_witness_nothing as PORTED in PLAN/refs**
