### PR TITLE
Port: test_function_cache

### DIFF
--- a/PLAN.md
+++ b/PLAN.md
@@ -38,13 +38,13 @@ Keep this document up to date as a living record of porting progress from the Py
  - ✅ test_can_target_a_score_downwards
  - ✅ test_can_choose_full_64_bits
  - ✅ test_error_on_unbounded_test_function
- - ✅ test_can_target_a_score_upwards_to_interesting
- - ✅ test_targeting_when_most_do_not_benefit
+- ✅ test_can_target_a_score_upwards_to_interesting
+- ✅ test_targeting_when_most_do_not_benefit
+- ✅ test_reduces_additive_pairs
+- ✅ test_reuses_results_from_the_database
+- ✅ test_function_cache
 
 ## Missing Python Tests To Port
-- test_reduces_additive_pairs
-- test_reuses_results_from_the_database
-- test_function_cache
 - test_finds_a_local_maximum
 - test_target_and_reduce
 

--- a/minithesis.cabal
+++ b/minithesis.cabal
@@ -22,7 +22,8 @@ library
       Minithesis
   build-depends:
       base >=4.14 && <5,
-      random >=1.2 && <1.3
+      random >=1.2 && <1.3,
+      containers
 
   default-extensions:
       ScopedTypeVariables

--- a/src/Minithesis.hs
+++ b/src/Minithesis.hs
@@ -19,6 +19,7 @@ module Minithesis
     satisfying,
     mixOf,
     named,
+    cachedTestFunction,
     TestCase,
     forChoices,
     newTestCase,
@@ -38,6 +39,7 @@ import Control.Exception (Exception, SomeException, throwIO, try)
 import Control.Monad (forM_, replicateM, unless, when)
 import Data.IORef
 import qualified Data.List as L
+import qualified Data.Map.Strict as Map
 import Data.Maybe (fromMaybe, isJust, isNothing)
 import Data.Word (Word64)
 import qualified System.IO.Unsafe as Unsafe
@@ -767,3 +769,57 @@ cachedEvaluate state choices = do
       st <- finaliseStatus tc
       modifyIORef' evalCache ((choices, st) :)
       pure st
+
+-- | Create a cached version of a test function over explicit choice sequences.
+cachedTestFunction :: (TestCase -> IO ()) -> IO ([Word64] -> IO Status)
+cachedTestFunction testFn = do
+  cacheRef <- newIORef cacheEmpty
+  pure $ \choices -> do
+    cache <- readIORef cacheRef
+    case cacheLookup cache choices of
+      Just st -> pure st
+      Nothing -> do
+        tc <- forChoicesWithPrinter choices False (const (pure ()))
+        r <- try (testFn tc) :: IO (Either SomeException ())
+        case r of
+          Left _ -> do
+            m <- getStatus tc
+            case m of
+              Nothing -> do
+                _ <- try (markStatus tc Interesting) :: IO (Either StopTest a)
+                pure ()
+              Just _ -> pure ()
+          Right _ -> pure ()
+        st <- finaliseStatus tc
+        recorded <- getChoices tc
+        modifyIORef' cacheRef (\tree -> cacheInsert tree recorded st)
+        pure st
+
+data CacheTree
+  = CacheBranch !(Map.Map Word64 CacheTree)
+  | CacheLeaf !Status
+
+cacheEmpty :: CacheTree
+cacheEmpty = CacheBranch Map.empty
+
+cacheLookup :: CacheTree -> [Word64] -> Maybe Status
+cacheLookup (CacheLeaf status) _ = Just status
+cacheLookup (CacheBranch _) [] = Just Overrun
+cacheLookup (CacheBranch m) (c : cs) =
+  case Map.lookup c m of
+    Nothing -> Nothing
+    Just child -> cacheLookup child cs
+
+cacheInsert :: CacheTree -> [Word64] -> Status -> CacheTree
+cacheInsert node [] status
+  | status == Overrun = node
+  | otherwise = CacheLeaf status
+cacheInsert (CacheLeaf _) choices status = cacheInsert cacheEmpty choices status
+cacheInsert (CacheBranch m) (c : cs) status
+  | null cs && status /= Overrun = CacheBranch (Map.insert c (CacheLeaf status) m)
+  | otherwise =
+      let child = case Map.lookup c m of
+            Just (CacheBranch m') -> CacheBranch m'
+            _ -> cacheEmpty
+          child' = cacheInsert child cs status
+       in CacheBranch (Map.insert c child' m)


### PR DESCRIPTION
## Summary
- port Python's test_function_cache to Hspec/Tasty
- add cachedTestFunction helper mirroring reference implementation
- extend PLAN.md and cabal dependencies

## Testing
- make format
- cabal test all --test-show-details=direct
- hlint src/Minithesis.hs
test/Minithesis/Spec.hs
test/Spec.hs
test/TastyMain.hs
