### PR TITLE
Restrict TestCase mutation to scoped handles

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -15,6 +15,7 @@
   - This avoids unnecessary rebases later.
 - The Haskell test suite must be written with Hspec while still providing runners for both Hspec and Tasty.
 - Port the Python reference test suite incrementally, marking each Python test as `-- PORTED` once its Haskell counterpart exists.
+- The `gh` CLI is available; use it for GitHub operations (e.g., opening PRs) when automation helps.
 
 ## Formatting
 - Ormolu version: we use `ormolu-0.7.7.0` in CI. Install it locally once so results match:

--- a/test/Minithesis/Spec.hs
+++ b/test/Minithesis/Spec.hs
@@ -226,7 +226,7 @@ spec = do
   describe "shrinking" $ do
     it "finds small list (port of test_finds_small_list)" $ do
       let shrinkProperty =
-            MP.withRunOptions (\o -> o {runQuiet = False, runMaxExamples = 200, runSeed = Just 0}) $
+            MP.withRunOptions (\o -> o {runQuiet = False, runSeed = Just 0}) $
               MP.property
                 ( \tc -> do
                     ls <- any tc (lists (integers 0 10000) Nothing Nothing)
@@ -248,7 +248,7 @@ spec = do
               let k = fromInteger n
               replicateM k (integers 0 10000)
           shrinkBadListProperty =
-            MP.withRunOptions (\o -> o {runQuiet = False, runMaxExamples = 200, runSeed = Just 0}) $
+            MP.withRunOptions (\o -> o {runQuiet = False, runSeed = Just 0}) $
               MP.property
                 ( \tc -> do
                     ls <- any tc badList

--- a/test/Minithesis/Spec.hs
+++ b/test/Minithesis/Spec.hs
@@ -12,17 +12,17 @@ import Prelude hiding (any)
 
 spec :: Spec
 spec = do
-  describe "TestCase.forChoices" $ do
+  describe "TestCase.withChoices" $ do
     it "raises Frozen when interacting with a completed test case" $ do
-      tc <- forChoices [0] False
-      setStatus tc Valid
-      markStatus tc Interesting `shouldThrow` isFrozen
-      choice tc 10 `shouldThrow` isFrozen
-      forcedChoice tc 10 `shouldThrow` isFrozen
+      withChoices [0] False $ \tc -> do
+        setStatus tc Valid
+        markStatus tc Interesting `shouldThrow` isFrozen
+        choice tc 10 `shouldThrow` isFrozen
+        forcedChoice tc 10 `shouldThrow` isFrozen
   describe "TestCase.choice" $ do
     it "rejects bounds that exceed 64 bits" $ do
-      tc <- forChoices [] False
-      choice tc (2 ^ (64 :: Integer)) `shouldThrow` isValueError
+      withChoices [] False $ \tc ->
+        choice tc (2 ^ (64 :: Integer)) `shouldThrow` isValueError
   describe "runTest" $ do
     it "can choose the full 64-bit range" $ do
       runWithOptions_ (\o -> o {runQuiet = True}) $ \tc -> do
@@ -53,9 +53,9 @@ spec = do
     it "prints a top-level weighted" $ do
       logsRef <- newIORef []
       let collect msg = modifyIORef' logsRef (++ [msg])
-      tc <- forChoicesWithPrinter [] True collect
-      res <- weighted tc 0.5
-      res `shouldBe` False
+      withChoicesWithPrinter [] True collect $ \tc -> do
+        res <- weighted tc 0.5
+        res `shouldBe` False
       readIORef logsRef `shouldReturn` ["weighted(0.5): False"]
 
     it "impossible weighted still allows later Failure" $ do
@@ -89,8 +89,8 @@ spec = do
 
   describe "TestCase.forcedChoice" $ do
     it "rejects bounds that exceed 64 bits" $ do
-      tc <- forChoices [] False
-      forcedChoice tc (2 ^ (64 :: Integer)) `shouldThrow` isValueError
+      withChoices [] False $ \tc ->
+        forcedChoice tc (2 ^ (64 :: Integer)) `shouldThrow` isValueError
 
   describe "generators" $ do
     it "size bounds on list" $ do


### PR DESCRIPTION
## Summary
- wrap TestCase access in scoped constructors so mutable refs never escape
- rework runner/cache/strategies to use the new API and keep shrink caching per run
- document gh CLI availability and update specs to the new helpers

## Testing
- make format
- hlint examples/hspec/Examples/HspecSpec.hs
examples/hspec/Spec.hs
examples/tasty/Spec.hs
src/Minithesis.hs
src/Minithesis/Cache.hs
src/Minithesis/Hspec.hs
src/Minithesis/Property.hs
src/Minithesis/Runner.hs
src/Minithesis/Strategy.hs
src/Minithesis/Tasty.hs
src/Minithesis/TestCase.hs
test/Minithesis/Spec.hs
test/Spec.hs
- cabal test minithesis-test --test-show-details=direct --test-options="--profile"
- MINITHESIS_MAX_EXAMPLES=100000 cabal test minithesis-test --test-show-details=direct --test-options="--profile --jobs 16"
