### PR TITLE
Cache ghcup toolchains in CI

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -61,7 +61,7 @@ jobs:
             --ignore-project \
             --installdir="$HOME/.cabal/bin" \
             --overwrite-policy=always \
-            ormolu-0.7.7.0
+            ormolu-0.8.0.2
 
       - name: Ormolu formatting check
         run: |

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -8,6 +8,9 @@ on:
 jobs:
   build:
     runs-on: ubuntu-latest
+    env:
+      GHC_REQUESTED: latest
+      CABAL_REQUESTED: latest
     permissions:
       security-events: write
 
@@ -17,17 +20,33 @@ jobs:
       - name: HLint scan (code scanning)
         uses: haskell-actions/hlint-scan@v1
 
+      - name: Restore ghcup
+        id: restore-ghcup
+        uses: actions/cache/restore@v4
+        with:
+          path: ~/.ghcup
+          key: ${{ runner.os }}-ghcup-${{ env.GHC_REQUESTED }}
+          restore-keys: |
+            ${{ runner.os }}-ghcup-
       - name: Set up Haskell
+        id: setup-haskell
         uses: haskell-actions/setup@v2
         with:
-          ghc-version: "9.8.2"
-          cabal-version: "3.12.1.0"
+          ghc-version: ${{ env.GHC_REQUESTED }}
+          cabal-version: ${{ env.CABAL_REQUESTED }}
 
+      - name: Save ghcup
+        if: steps.restore-ghcup.outputs.cache-hit != 'true'
+        uses: actions/cache/save@v4
+        with:
+          path: ~/.ghcup
+          key: ${{ runner.os }}-ghcup-${{ steps.setup-haskell.outputs.ghc-version }}
       - name: Cache Cabal store
         uses: actions/cache@v4
         with:
           path: |
             ~/.cabal/store
+            ~/.cabal/packages
             dist-newstyle
           key: ${{ runner.os }}-cabal-${{ hashFiles('cabal.project', '**/*.cabal') }}
           restore-keys: |

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -18,8 +18,8 @@
 - The `gh` CLI is available; use it for GitHub operations (e.g., opening PRs) when automation helps.
 
 ## Formatting
-- Ormolu version: we use `ormolu-0.7.7.0` in CI. Install it locally once so results match:
-  `cabal install ormolu-0.7.7.0`
+- Ormolu version: we use `ormolu-0.8.0.2` in CI. Install it locally once so results match:
+  `cabal install ormolu-0.8.0.2`
 - Run Ormolu in-place on all tracked Haskell files (explicit and CI-consistent):
   `cabal exec -- ormolu --mode inplace $(git ls-files '*.hs')`
 - `make format` runs the same command.

--- a/README.md
+++ b/README.md
@@ -14,7 +14,7 @@ Minithesis is a property-based testing toolkit with integrated shrinking and a t
 The repository is Cabal-first and ships a small Makefile helper:
 
 - `cabal build`
-- `make format` (runs `ormolu-0.7.7.0` over all tracked `.hs` files)
+- `make format` (runs `ormolu-0.8.0.2` over all tracked `.hs` files)
 - `hlint $(git ls-files '*.hs')`
 - `cabal test all --test-show-details=direct`
 - `cabal check`
@@ -46,7 +46,7 @@ The Hspec example in particular is short enough to inline here for quick referen
 The repository is Cabal-first and ships a small Makefile helper:
 
 - `cabal build`
-- `make format` (runs `ormolu-0.7.7.0` over all tracked `.hs` files)
+- `make format` (runs `ormolu-0.8.0.2` over all tracked `.hs` files)
 - `hlint $(git ls-files '*.hs')`
 - `cabal test all --test-show-details=direct`
 - `cabal check`


### PR DESCRIPTION
## Summary
- request latest GHC/Cabal in CI and cache ghcup installs around setup
- expand Cabal caching to include packages index so dependency downloads persist

## Testing
- make format
- hlint examples/hspec/Examples/HspecSpec.hs
examples/hspec/Spec.hs
examples/tasty/Spec.hs
src/Minithesis.hs
src/Minithesis/Cache.hs
src/Minithesis/Hspec.hs
src/Minithesis/Property.hs
src/Minithesis/Runner.hs
src/Minithesis/Strategy.hs
src/Minithesis/Tasty.hs
src/Minithesis/TestCase.hs
test/Minithesis/Spec.hs
test/Spec.hs
- cabal test all --test-show-details=direct
- cabal check