### PR TITLE
Remove unused hang-repro flag

### DIFF
--- a/minithesis.cabal
+++ b/minithesis.cabal
@@ -26,11 +26,6 @@ flag ci-tests
   manual: True
   default: False
 
-flag hang-repro
-  description: Build the sydtest concurrency reproducer suite
-  manual: True
-  default: False
-
 library
   exposed-modules:
     Minithesis

--- a/src/Minithesis/Integration.hs
+++ b/src/Minithesis/Integration.hs
@@ -48,3 +48,4 @@ scopedCallsite ignoreSuffixes =
   where
     isInternal name = any (`isSuffixOf` name) ignoreSuffixes
     render name src = srcLocFile src <> ":" <> show (srcLocStartLine src) <> "#" <> name
+{-# ANN scopedCallsite ("HLint: ignore Redundant bracket" :: String) #-}


### PR DESCRIPTION
## Summary
- drop the unused `hang-repro` flag so the declared and used flag sets match
- annotate `scopedCallsite` to keep Ormolu+HLint happy without reintroducing braces

## Testing
- make format
- hlint $(git ls-files '*.hs')
- cabal test all --test-show-details=direct
- cabal check
