### PR TITLE
Add Sydtest adapter example

### DIFF
--- a/README.md
+++ b/README.md
@@ -84,18 +84,18 @@ Minithesis always runs with a failure database. Counterexamples are persisted to
 The Hspec example in particular is short enough to inline here for quick reference:
 
 ```haskell
-module Examples.HspecSpec (spec) where
+module Examples.SydtestSpec (spec) where
 
 import Data.List (sort)
 import Minithesis
-import qualified Minithesis.Hspec as MH
-import Test.Hspec
+import qualified Minithesis.Sydtest as MS
+import Test.Syd
 import Prelude hiding (any)
 
 spec :: Spec
 spec =
   describe "sorting" $ do
-    MH.prop "sorting twice equals sorting once" $
+    MS.prop "sorting twice equals sorting once" $
       withTests 200 $ \tc -> do
         xs <- any tc $ lists (integers (-10) 10) (Just 0) (Just 20)
         sort (sort xs) `shouldBe` sort xs

--- a/minithesis-sydtest/minithesis-sydtest.cabal
+++ b/minithesis-sydtest/minithesis-sydtest.cabal
@@ -37,6 +37,8 @@ test-suite minithesis-sydtest-test
   other-modules:
     Examples.SydtestSpec
     Paths_minithesis_sydtest
+  autogen-modules:
+    Paths_minithesis_sydtest
   ghc-options: -Wall -Wcompat -Wredundant-constraints
   build-depends:
     base,

--- a/minithesis-sydtest/minithesis-sydtest.cabal
+++ b/minithesis-sydtest/minithesis-sydtest.cabal
@@ -34,6 +34,9 @@ test-suite minithesis-sydtest-test
   hs-source-dirs:
     test
   main-is: Spec.hs
+  other-modules:
+    Examples.SydtestSpec
+    Paths_minithesis_sydtest
   ghc-options: -Wall -Wcompat -Wredundant-constraints
   build-depends:
     base,

--- a/minithesis-sydtest/test/Examples/SydtestSpec.hs
+++ b/minithesis-sydtest/test/Examples/SydtestSpec.hs
@@ -1,0 +1,15 @@
+module Examples.SydtestSpec (spec) where
+
+import Data.List (sort)
+import Minithesis
+import qualified Minithesis.Sydtest as MS
+import Test.Syd
+import Prelude hiding (any)
+
+spec :: Spec
+spec =
+  describe "Examples with Sydtest interface" $ do
+    MS.prop "sorting twice equals sorting once" $
+      withTests 200 $ \tc -> do
+        xs <- any tc $ lists (integers (-10) 10) (Just 0) (Just 20)
+        sort (sort xs) `shouldBe` sort xs

--- a/minithesis-sydtest/test/Spec.hs
+++ b/minithesis-sydtest/test/Spec.hs
@@ -1,18 +1,7 @@
 module Main (main) where
 
-import Data.List (sort)
-import Minithesis
-import qualified Minithesis.Sydtest as MS
+import qualified Examples.SydtestSpec as Examples
 import Test.Syd
-import Prelude hiding (any)
-
-spec :: Spec
-spec =
-  describe "Sydtest adapter" $ do
-    MS.prop "sorting twice equals sorting once" $
-      withTests 50 $ \tc -> do
-        xs <- any tc $ lists (integers (-5) 5) (Just 0) (Just 10)
-        sort (sort xs) `shouldBe` sort xs
 
 main :: IO ()
-main = sydTest spec
+main = sydTest Examples.spec


### PR DESCRIPTION
## Summary
- add a Sydtest example spec mirroring the existing Hspec and Tasty demos so the adapter package ships a concrete usage sample
- wire the example into the `minithesis-sydtest` test suite and surface it in the README’s code snippet, highlighting the Sydtest workflow

## Testing
- make format
- hlint minithesis minithesis-hspec minithesis-tasty minithesis-sydtest
- cabal test all --test-show-details=direct
- for pkg in minithesis minithesis-hspec minithesis-tasty minithesis-sydtest; do (cd "$pkg" && cabal check); done
