### PR TITLE
Point sydtest dependency at fork

### DIFF
--- a/cabal.project
+++ b/cabal.project
@@ -3,4 +3,4 @@ packages:
   minithesis-hspec
   minithesis-tasty
   minithesis-sydtest
-
+  /home/mark/lambdalabs/sydtest/sydtest

--- a/cabal.project
+++ b/cabal.project
@@ -3,4 +3,9 @@ packages:
   minithesis-hspec
   minithesis-tasty
   minithesis-sydtest
-  /home/mark/lambdalabs/sydtest/sydtest
+
+source-repository-package
+  type: git
+  location: https://github.com/lambdamechanic/sydtest.git
+  tag: b7c4a5f4e4f2182c2b590529f60eb7319703c5c6
+  subdir: sydtest

--- a/stack.yaml
+++ b/stack.yaml
@@ -4,5 +4,8 @@ packages:
   - minithesis-hspec
   - minithesis-tasty
   - minithesis-sydtest
-  - /home/mark/lambdalabs/sydtest/sydtest
-extra-deps: []
+extra-deps:
+  - git: https://github.com/lambdamechanic/sydtest.git
+    commit: b7c4a5f4e4f2182c2b590529f60eb7319703c5c6
+    subdirs:
+      - sydtest

--- a/stack.yaml
+++ b/stack.yaml
@@ -4,5 +4,5 @@ packages:
   - minithesis-hspec
   - minithesis-tasty
   - minithesis-sydtest
-extra-deps:
-  - sydtest-0.21.0.0
+  - /home/mark/lambdalabs/sydtest/sydtest
+extra-deps: []

--- a/stack.yaml.lock
+++ b/stack.yaml.lock
@@ -3,14 +3,7 @@
 # For more information, please see the documentation at:
 #   https://docs.haskellstack.org/en/stable/topics/lock_files
 
-packages:
-- completed:
-    hackage: sydtest-0.21.0.0@sha256:cffa077d86a835a7031735abf8922b1781f023100988d09880ff87357877e82f,2425
-    pantry-tree:
-      sha256: 40ad88d0081e463b5018d1dffeb41a4276e08f835f6fb0cc61d39a4f4d142c97
-      size: 2035
-  original:
-    hackage: sydtest-0.21.0.0
+packages: []
 snapshots:
 - completed:
     sha256: 0c4f0f7c5fad7c89d1df0c0f20eb1bd08020bd0295bb4ba1831fd023dd7da5cf

--- a/stack.yaml.lock
+++ b/stack.yaml.lock
@@ -3,7 +3,20 @@
 # For more information, please see the documentation at:
 #   https://docs.haskellstack.org/en/stable/topics/lock_files
 
-packages: []
+packages:
+- completed:
+    commit: b7c4a5f4e4f2182c2b590529f60eb7319703c5c6
+    git: https://github.com/lambdamechanic/sydtest.git
+    name: sydtest
+    pantry-tree:
+      sha256: 2951471bc85da65a7cc4b1f6cd4d57abc1ee2bcea799b8bdd21d6e747ab4b94b
+      size: 2188
+    subdir: sydtest
+    version: 0.21.0.0
+  original:
+    commit: b7c4a5f4e4f2182c2b590529f60eb7319703c5c6
+    git: https://github.com/lambdamechanic/sydtest.git
+    subdir: sydtest
 snapshots:
 - completed:
     sha256: 0c4f0f7c5fad7c89d1df0c0f20eb1bd08020bd0295bb4ba1831fd023dd7da5cf


### PR DESCRIPTION
## Summary
- stop using the hard-coded local checkout of sydtest
- instead pull sydtest from lambdamechanic/sydtest at commit b7c4a5f4e4f2182c2b590529f60eb7319703c5c6 via cabal.project/stack.yaml
- refresh stack's lock file accordingly

## Testing
- cabal build minithesis:minithesis-test
- cabal test all --test-show-details=direct
- for pkg in minithesis minithesis-hspec minithesis-tasty minithesis-sydtest; do (cd "$pkg" && cabal check); done
- stack build --dry-run (regenerated stack.yaml.lock)
